### PR TITLE
Fix macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ For now, the goal is to support the x86 Windows Version of the game.
 * [DevIL](http://openil.sourceforge.net/)
 * [OpenAL](https://www.openal.org/)
 
+**For macOS:** Use [Homebrew](https://brew.sh/) to install packages.
+
+```
+$ brew install cmake sdl2 unicorn glew devil openal-soft
+```
+
 ### Building
 
 From your desired project folder, run:

--- a/c11threads.h
+++ b/c11threads.h
@@ -20,6 +20,7 @@ Main project site: https://github.com/jtsiomb/c11threads
 #include <pthread.h>
 #include <sched.h>	/* for sched_yield */
 #include <sys/time.h>
+#include <assert.h>
 
 #define ONCE_FLAG_INIT	PTHREAD_ONCE_INIT
 
@@ -121,7 +122,12 @@ static inline int mtx_init(mtx_t *mtx, int type)
 	pthread_mutexattr_init(&attr);
 
 	if(type & mtx_timed) {
+#ifdef __APPLE__
+		// PTHREAD_MUTEX_TIMED_NP not supported on macOS
+		assert(0);
+#else
 		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_TIMED_NP);
+#endif
 	}
 	if(type & mtx_recursive) {
 		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);

--- a/emulation.h
+++ b/emulation.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+uint64_t GetTimerFrequency();
+uint64_t GetTimerValue();
+
 //FIXME: use these..
 typedef uint32_t Address;
 typedef uint32_t Size;

--- a/main.c
+++ b/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include <assert.h>
-#include <malloc.h>
 
 #include "common.h"
 #include "descriptor.h"
@@ -218,7 +217,8 @@ void LoadSection(Exe* exe, unsigned int sectionIndex) {
   PeSection* section = &exe->sections[sectionIndex];
 
   // Map memory for section
-  uint8_t* mem = (uint8_t*)memalign(0x1000, section->virtualSize);
+  uint8_t* mem;
+  assert(posix_memalign((void **)&mem, 0x1000, section->virtualSize) == 0);
 
   // Read data from exe and fill rest of space with zero
   fseek(exe->f, section->rawAddress, SEEK_SET);

--- a/shaders.h
+++ b/shaders.h
@@ -51,7 +51,7 @@ static const char* FragmentShader1Texture =
 #endif
 "\n"
 "void main() {\n"
-"  color = texture2D(tex0, vec2(uv0.x, uv0.y));\n"
+"  color = texture(tex0, vec2(uv0.x, uv0.y));\n"
 "  color *= diffuse;\n"
 "}\n";
 

--- a/uc_kvm.c
+++ b/uc_kvm.c
@@ -183,7 +183,8 @@ uc_err uc_open(uc_arch arch, uc_mode mode, uc_engine **uc) {
 
 
   // Load a small bios which boots CPU into protected mode
-  uint8_t* bios = memalign(0x100000, bios_size);
+  uint8_t *bios;
+  assert(posix_memalign((void **)&bios, 0x100000, bios_size) == 0);
   FILE* f = fopen("uc_kvm_loader", "rb");
   assert(f != NULL);
   fread(bios, 1, bios_size, f);


### PR DESCRIPTION
Just getting it building and started on macOS (Sierra, 10.12.6).

- Use `posix_memalign` instead of `memalign`
- Fix shader (need to use `texture`, not deprecated `texture2D`)
- Temp fix for undeclared functions being used
- `PTHREAD_MUTEX_TIMED_NP` not supported on macOS

![proof](https://i.imgur.com/QR6RBnP.png)
[More](https://imgur.com/a/T0KZa)