### PR TITLE
Rewrite hooks (now using HLT)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(OpenSWE1R)
 
+option(USE_VM "Use hardware virtualization backend for Unicorn-Engine" OFF)
+
+
 set(CMAKE_C_STANDARD 11)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
@@ -33,7 +36,7 @@ add_executable(openswe1r
   com/dplay.c
 )
 
-if(FALSE)
+if(USE_VM)
   target_compile_definitions(openswe1r PUBLIC -DUC_KVM)
   target_sources(openswe1r PUBLIC
     uc_kvm.c

--- a/emulation.h
+++ b/emulation.h
@@ -26,9 +26,8 @@ void* Memory(uint32_t address);
 
 // Hook API
 
-// If size is 0 this is a code hook
-//FIXME: Use proper type for callback!
-void CreateBreakpoint(uint32_t address, void* callback, void* user);
+Address CreateHlt();
+void AddHltHandler(Address address, void(*callback)(void* uc, Address address, void* user_data), void* user_data);
 Address CreateCallback(void* callback, void* user);
 
 // Thread API

--- a/main.h
+++ b/main.h
@@ -21,13 +21,13 @@ Address CreateInterface(const char* name, unsigned int slotCount);
 void AddExport(const char* name, void* callback, Address address);
 
 #define HACKY_IMPORT_BEGIN(_name) \
-  static void Hook_ ## _name (void* uc, uint64_t address, uint32_t _size, void* user_data); \
+  static void Hook_ ## _name (void* uc, Address address, void* user_data); \
   __attribute__((constructor)) static void Register_ ## _name () { \
     const char* name = #_name; \
     printf("Registering hook for '%s'\n", name); \
     AddExport(name, Hook_ ## _name, 0); \
   } \
-  static void Hook_ ## _name (void* uc, uint64_t _address, uint32_t _size, void* _user_data) { \
+  static void Hook_ ## _name (void* uc, Address _address, void* _user_data) { \
     bool silent = false; \
     \
     int eip; \


### PR DESCRIPTION
Improves performance and make KVM functional. It also avoids some ugly emulation errors we might have gotten with the old approach

This fixes #60 , works around the need for #57 , closes #54 and touches parts of #23 (KVM support).

KVM is exposed via the cmake option: `USE_VM`. So `cmake .. -DUSE_VM=ON` will get you KVM support.
The option name was chosen because I expect more hardware based backends in the future, such as HAXM.

TODO after merge:

- Cleanup code
- Add feature request for HAXM