### PR TITLE
Remove DevIL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(Unicorn REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(SDL2 REQUIRED)
-find_package(DevIL REQUIRED)
 find_package(OpenAL REQUIRED)
 
 include_directories(SYSTEM
@@ -17,7 +16,6 @@ include_directories(SYSTEM
   ${OPENGL_INCLUDE_DIR}
   ${GLEW_INCLUDE_DIRS}
   ${SDL2_INCLUDE_DIR}
-  ${IL_INCLUDE_DIR}
   ${OPENAL_INCLUDE_DIR}
 )
 
@@ -48,7 +46,5 @@ target_link_libraries(openswe1r
   ${OPENGL_LIBRARIES}
   ${GLEW_LIBRARIES}
   ${SDL2_LIBRARY}
-  ${IL_LIBRARIES}
-  ${ILU_LIBRARIES}
   ${OPENAL_LIBRARY}
 )

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ For now, the goal is to support the x86 Windows Version of the game.
 * [Unicorn-Engine](http://www.unicorn-engine.org/)
 * [SDL2](https://www.libsdl.org/)
 * [GLEW](http://glew.sourceforge.net/)
-* [DevIL](http://openil.sourceforge.net/)
 * [OpenAL](https://www.openal.org/)
 
 ### Building

--- a/main.c
+++ b/main.c
@@ -23,8 +23,6 @@ static SDL_Window* sdlWindow;
 
 #include <GL/glew.h>
 
-#include <IL/il.h>
-
 #include "com/d3d.h"
 #include "com/ddraw.h"
 #include "com/dinput.h"
@@ -1121,46 +1119,6 @@ HACKY_IMPORT_BEGIN(QueryPerformanceFrequency)
   *(uint64_t*)Memory(stack[1]) = GetTimerFrequency();
   eax = 1; // BOOL - but doc: hardware supports a high-resolution performance counter = nonzero return
   esp += 1 * 4;
-HACKY_IMPORT_END()
-
-HACKY_IMPORT_BEGIN(LoadImageA)
-  hacky_printf("hinst 0x%" PRIX32 "\n", stack[1]);
-  hacky_printf("lpszName 0x%" PRIX32 " ('%s')\n", stack[2], (char*)Memory(stack[2]));
-  hacky_printf("uType 0x%" PRIX32 "\n", stack[3]);
-  hacky_printf("cxDesired 0x%" PRIX32 "\n", stack[4]);
-  hacky_printf("cyDesired 0x%" PRIX32 "\n", stack[5]);
-  hacky_printf("fuLoad 0x%" PRIX32 "\n", stack[6]);
-
-  char* path = TranslatePath((const char*)Memory(stack[2]));
-  ILboolean ret = ilLoadImage(path);
-  free(path);
-  if (ret == IL_TRUE) {
-    ILint width = ilGetInteger(IL_IMAGE_WIDTH);
-    ILint height = ilGetInteger(IL_IMAGE_HEIGHT);
-    printf("Loaded %d x %d texture\n", width, height);
-
-    Address bitmapAddress = Allocate(sizeof(BITMAP));
-    BITMAP* bitmap = (BITMAP*)Memory(bitmapAddress);
-
-    bitmap->bmType = 0; //FIXME
-    bitmap->bmWidth = width;
-    bitmap->bmHeight = height;
-    bitmap->bmWidthBytes = 0; //FIXME
-    bitmap->bmPlanes = 0; //FIXME
-    bitmap->bmBitsPixel = 0; //FIXME
-
-    Size size = width * height * 3;
-    bitmap->bmBits = Allocate(size);
-    memcpy(Memory(bitmap->bmBits), ilGetData(), size);
-
-    //FIXME: IL cleanup
-
-    eax = bitmapAddress;    
-  } else {
-    printf("Loading failed!\n");
-    eax = 0;
-  }
-  esp += 6 * 4;
 HACKY_IMPORT_END()
 
 HACKY_IMPORT_BEGIN(GetObjectA)
@@ -3697,8 +3655,6 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
       return 1;
     }
-
-    ilInit();
 
 
     //FIXME: This is ugly but gets the job done.. for now


### PR DESCRIPTION
This was a leftover from Re-Volt, see #2 

DevIL is the largest dependency in OpenSWE1R and it's currently not being used. There is no reason we should keep it around.

*(I'll merge this PR later today if nobody vetos)*