### PR TITLE
Improve shaders

### DIFF
--- a/main.c
+++ b/main.c
@@ -3727,8 +3727,9 @@ int main(int argc, char* argv[]) {
     GLuint fragmentShader = CreateShader(FragmentShader1Texture, GL_FRAGMENT_SHADER);
     shader1Texture = CreateShaderProgram(vertexShader, fragmentShader);
   }
-  LinkShaderProgram(shader1Texture);
+  bool linked = LinkShaderProgram(shader1Texture);
   PrintShaderProgramLog(shader1Texture);
+  assert(linked);
   glUseProgram(shader1Texture); //FIXME: Hack..
   printf("-- Loading exe\n");
   Exe* exe = LoadExe(exeName);

--- a/main.c
+++ b/main.c
@@ -383,6 +383,8 @@ bool fogEnable;
 float fogStart;
 float fogEnd;
 float projectionMatrix[16];
+float clipScale[3];
+float clipOffset[3];
 
 static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexFormat) {
   unsigned int texCount = ((vertexFormat & 0xF00) >> 8);
@@ -426,6 +428,9 @@ static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexForma
               ((fogColor >> 16) & 0xFF) / 255.0,
               ((fogColor >> 8) & 0xFF) / 255.0,
               (fogColor & 0xFF) / 255.0);
+
+  glUniform3fv(glGetUniformLocation(program, "clipScale"), 1, clipScale);
+  glUniform3fv(glGetUniformLocation(program, "clipOffset"), 1, clipOffset);
 
 #if 1
   // Hack to disable texture if tex0 is used - doesn't work?!
@@ -2933,7 +2938,15 @@ HACKY_COM_BEGIN(IDirect3DViewport3, 17)
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   D3DVIEWPORT2* vp = (D3DVIEWPORT2*)Memory(stack[2]);
   assert(vp->dwSize == sizeof(D3DVIEWPORT2));
-  printf("- w:%" PRIu32 " h:%" PRIu32 ", zrange: %f %f\n", vp->dwWidth, vp->dwHeight, vp->dvMinZ, vp->dvMaxZ);
+
+  clipScale[0] = 2.0f / vp->dvClipWidth;
+  clipScale[1] = 2.0f / vp->dvClipHeight;
+  clipScale[2] = 2.0f / (vp->dvMaxZ - vp->dvMinZ);
+  clipOffset[0] = -vp->dvClipX * clipScale[0] - 1.0f;
+  clipOffset[1] = -vp->dvClipY * clipScale[1] - 1.0f;
+  clipOffset[2] = -vp->dvMinZ * clipScale[2] - 1.0f;
+  glViewport(vp->dwX, vp->dwY, vp->dwWidth, vp->dwHeight);
+
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 2 * 4;
 HACKY_COM_END()

--- a/shaders.h
+++ b/shaders.h
@@ -51,7 +51,7 @@ static const char* FragmentShader1Texture =
 #endif
 "\n"
 "void main() {\n"
-"  color = texture2D(tex0, vec2(uv0.x, uv0.y));\n"
+"  color = texture(tex0, uv0);\n"
 "  color *= diffuse;\n"
 "}\n";
 

--- a/shaders.h
+++ b/shaders.h
@@ -10,6 +10,8 @@ static const char* VertexShader1Texture =
 "uniform float fogStart;\n"
 "uniform float fogEnd;\n"
 "uniform vec3 fogColor;\n"
+"uniform vec3 clipScale;\n"
+"uniform vec3 clipOffset;\n"
 "\n"
 "in vec4 positionIn;\n"
 "in vec4 diffuseIn;\n"
@@ -21,15 +23,9 @@ static const char* VertexShader1Texture =
 "out vec2 uv0;\n"
 "\n"
 "void main() {\n"
-"  vec4 p = projectionMatrix * vec4(positionIn.xyz, 1.0); /* positionIn.w */;\n"
-"  p /= p.w;\n"
-
-"p = vec4(positionIn.xyz, 1.0);\n"
-
-"  gl_Position = vec4(p.xy / vec2(640.0, -480.0) * 2.0 + vec2(-1.0, 1.0), p.z, 1.0);\n"
-
-"gl_Position = vec4(p.xy / vec2(640.0, -480.0) * 2.0 - vec2(1.0, -1.0), 0.0, 1.0);\n"
-
+"  gl_Position = vec4(positionIn.xyz * clipScale + clipOffset, 1.0);\n"
+"  gl_Position /= positionIn.w;\n"
+"  gl_Position.y = -gl_Position.y;\n"
 "  diffuse = diffuseIn.bgra;\n"
 "  specular = specularIn.bgra;\n"
 "  uv0 = uv0In;\n"


### PR DESCRIPTION
3 Changes:

* Fix the issue brought up in #52 where `texture2D()` was used accidentally.
* Improve the vertex transformations. I'm not sure if they are 100% correct. Also some smaller issues like #66 and #65 still exist.
* Assert that the shader linked successfully.

This does not implement depth testing or fog yet, because those are more complicated.
Fog in D3D6 might be based on the projection matrix, and depth clears are not working as expected currently.

*(I'll keep this for a day or so, then merge if there is no veto)*