### PR TITLE
Work towards portability

### DIFF
--- a/common.h
+++ b/common.h
@@ -4,6 +4,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(_WIN32)
+#  include <malloc.h>
+#else
+#  include <stdlib.h>
+#endif
+
 static bool IsZero(const void* data, size_t size) {
   uint8_t* bytes = (uint8_t*)data;
   for(size_t i = 0; i < size; i++) {
@@ -20,6 +26,25 @@ static uint32_t AlignDown(uint32_t address, uint32_t size) {
 
 static uint32_t AlignUp(uint32_t address, uint32_t size) {
   return AlignDown(address + size - 1, size);
+}
+
+static void* aligned_malloc(size_t alignment, size_t size) {
+  void* ptr;
+#if defined(_WIN32)
+  ptr = _aligned_malloc(size, alignment);
+#else
+  posix_memalign(&ptr, alignment, size);
+#endif
+  assert(ptr != NULL);
+  return ptr;
+}
+
+static void aligned_free(void* ptr) {
+#if defined(_WIN32)
+  _aligned_free(ptr);
+#else
+  free(ptr);
+#endif
 }
 
 #endif

--- a/common.h
+++ b/common.h
@@ -1,3 +1,6 @@
+#ifndef __OPENSWE1R_COMMON_H__
+#define __OPENSWE1R_COMMON_H__
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -18,3 +21,5 @@ static uint32_t AlignDown(uint32_t address, uint32_t size) {
 static uint32_t AlignUp(uint32_t address, uint32_t size) {
   return AlignDown(address + size - 1, size);
 }
+
+#endif

--- a/emulation.c
+++ b/emulation.c
@@ -325,7 +325,7 @@ void InitializeEmulation() {
 
 #ifndef UC_KVM
   // Setup segments
-  SegmentDescriptor* gdtEntries = (SegmentDescriptor*)memalign(ucAlignment, AlignUp(gdtSize, ucAlignment));
+  SegmentDescriptor* gdtEntries = (SegmentDescriptor*)aligned_malloc(ucAlignment, AlignUp(gdtSize, ucAlignment));
   memset(gdtEntries, 0x00, gdtSize);
 
   gdtEntries[14] = CreateDescriptor(0x00000000, 0xFFFFF000, true);  // CS
@@ -375,12 +375,12 @@ void InitializeEmulation() {
 #endif
 
   // Map and set TLS (not exposed via flat memory)
-  uint8_t* tls = memalign(ucAlignment, tlsSize);
+  uint8_t* tls = aligned_malloc(ucAlignment, tlsSize);
   memset(tls, 0xBB, tlsSize);
   err = uc_mem_map_ptr(uc, tlsAddress, tlsSize, UC_PROT_WRITE | UC_PROT_READ, tls);
 
   // Allocate a heap
-  heap = memalign(ucAlignment, heapSize);
+  heap = aligned_malloc(ucAlignment, heapSize);
   memset(heap, 0xAA, heapSize);
   MapMemory(heap, heapAddress, heapSize, true, true, true);
 }
@@ -407,7 +407,7 @@ unsigned int CreateEmulatedThread(uint32_t eip) {
   // Map and set stack
   //FIXME: Use requested size
   if (stack == NULL) {
-    stack = memalign(ucAlignment, stackSize);
+    stack = aligned_malloc(ucAlignment, stackSize);
     MapMemory(stack, stackAddress, stackSize, true, true, false);
   }
   static int threadId = 0;

--- a/emulation.c
+++ b/emulation.c
@@ -14,6 +14,8 @@
 #endif
 #include <malloc.h>
 
+#include "SDL.h"
+
 #include "common.h"
 #include "descriptor.h"
 #include "emulation.h"
@@ -167,7 +169,7 @@ static void UcTraceHook(void* uc, uint64_t address, uint32_t size, void* user_da
   uc_reg_read(uc, UC_X86_REG_EAX, &eax);
   uc_reg_read(uc, UC_X86_REG_ESI, &esi);
   static uint32_t id = 0;
-  printf("%7" PRIu32 " TRACE Emulation at 0x%X (ESP: 0x%X); eax = 0x%08" PRIX32 " esi = 0x%08" PRIX32 " (TS: %" PRIu64 ")\n", id++, eip, esp, eax, esi, GetTimerValue());
+  printf("%7" PRIu32 " TRACE Emulation at 0x%X (ESP: 0x%X); eax = 0x%08" PRIX32 " esi = 0x%08" PRIX32 " (TS: %" PRIu64 ")\n", id++, eip, esp, eax, esi, SDL_GetTicks());
 }
 
 void MapMemory(void* memory, uint32_t address, uint32_t size, bool read, bool write, bool execute) {

--- a/main.c
+++ b/main.c
@@ -210,7 +210,7 @@ void LoadSection(Exe* exe, unsigned int sectionIndex) {
   PeSection* section = &exe->sections[sectionIndex];
 
   // Map memory for section
-  uint8_t* mem = (uint8_t*)memalign(0x1000, section->virtualSize);
+  uint8_t* mem = (uint8_t*)aligned_malloc(0x1000, section->virtualSize);
 
   // Read data from exe and fill rest of space with zero
   fseek(exe->f, section->rawAddress, SEEK_SET);

--- a/main.c
+++ b/main.c
@@ -83,7 +83,6 @@ uint32_t tls[1000] = {0};
 #include "shader.h"
 
 
-#include <unistd.h> // Hack for debug sleep
 #include "windows.h" // Hack while exports are not ready
 // HACK:
 #include <unicorn/unicorn.h>
@@ -798,7 +797,7 @@ HACKY_IMPORT_BEGIN(MessageBoxA)
   hacky_printf("lpText 0x%" PRIX32 " ('%s')\n", stack[2], (char*)Memory(stack[2]));
   hacky_printf("lpCaption 0x%" PRIX32 " ('%s')\n", stack[3], (char*)Memory(stack[3]));
   hacky_printf("uType 0x%" PRIX32 "\n", stack[4]);
-  usleep(5000*1000);
+  SDL_Delay(5000);
   eax = 2; // Cancel was selected
   esp += 4 * 4;
 HACKY_IMPORT_END()
@@ -1502,7 +1501,7 @@ HACKY_IMPORT_BEGIN(FindFirstFileA)
     const char* none[] = { NULL };
     dirlisting = none;
     printf("Unknown pattern: '%s'\n", pattern);
-    usleep(1000*3000);
+    SDL_Delay(3000);
   }
 
   if (*dirlisting) {


### PR DESCRIPTION
Work on portability to attract more developers.


First, this adds include guards to the common.h header

Then it replaces replaces memalign with a custom function (as suggested in #52 ). A solution for win32 and posix is provided.
Better conditional checking is possible, but for now, the posix fallback should be fine.
The naming for this function is very unfortunate. It's very similar to the Win32 function, but I only noticed this after writing the posix version. To make matters worse, the order of the parameters for the Win32 function is swapped.

Lastly, this replaces the existing timer code with SDL timer functions.
I've added the SDL calls directly in the code, without abstraction. Wether we replace SDL by another platform abstraction (possibly our own as a stable interface) in the future, could be discussed. However, for now, this should be fine as SDL and Unicorn are considered stable interfaces for most things.

A second SDL related commit also replaces usleep with `SDL_Delay`.

*(If nobody vetos this within a day or so, it will get merged)*