### PR TITLE
Remove platform specific malloc.h include from main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include <assert.h>
-#include <malloc.h>
 
 #include "common.h"
 #include "descriptor.h"


### PR DESCRIPTION
Forgot this one in #75 and #77  (because I'm stupid).
Thanks to @mborgerson for noticing this.

*(I'll keep this opened for only a couple of minutes and merge if there's no veto)*