### PR TITLE
Use the default binary name (swep1rcr.exe)

### DIFF
--- a/main.c
+++ b/main.c
@@ -129,7 +129,7 @@ Address CreateInterface(const char* name, unsigned int slotCount) {
 
 
 Exe* exe; //FIXME: This is hack. I feel this shouldn't be exposed aside from the loader
-const char* exeName = "SWEP1RCR_newer_patch.EXE";
+const char* exeName = "swep1rcr.exe";
 
 static char* TranslatePath(const char* path) {
   char* newPath = malloc(strlen(path) + 1);
@@ -576,7 +576,7 @@ HACKY_IMPORT_BEGIN(SetHandleCount)
 HACKY_IMPORT_END()
 
 HACKY_IMPORT_BEGIN(GetCommandLineA)
-  const char* cmd = "SWEP1RCR_newer_patch.EXE";
+  const char* cmd = "swep1rcr.exe";
   Address tmp = Allocate(strlen(cmd) + 1);
   strcpy((char*)Memory(tmp), cmd);
   eax = tmp;


### PR DESCRIPTION
"swep1rcr.exe" is the lowercase version of the binay name for the full retail release, the patched binary from the LucasArts FTP and also the name of the binary in the web-demo version.

The lowercase variant is present on disc, but will be renamed to uppercase during installation.
However, the lowercase version is probably better (for us) as it's easier to handle on case-sensitive OS.
`cabextract` also has an `--lowercase` option (for use with the web-demo).

Closes #32 

*(Will be merged soon if there is no veto)*