### PR TITLE
Add support for Microsoft Visual C++

### DIFF
--- a/emulation.c
+++ b/emulation.c
@@ -31,7 +31,7 @@ static uint32_t stackSize = 16 * 1024 * 1024; // 4 MiB stack should be PLENTY
 
 #define HEAP_ADDRESS 0x0D000000
 static uint32_t heapAddress = HEAP_ADDRESS;
-static uint32_t heapSize = 2048 * 1024 * 1024; // 2048 MiB
+static uint32_t heapSize = 1024 * 1024 * 1024; // 1024 MiB
 
 static uc_engine *uc;
 static uint32_t ucAlignment = 0x1000;

--- a/export.h
+++ b/export.h
@@ -1,7 +1,9 @@
 #include <stdio.h>
 
+#include "main.h"
+
 #define EXPORT_STDCALL(library, returnType, symbol, ...) \
-__attribute__((constructor)) void export_ ## library ## _ ## symbol() { \
+INITIALIZER(export_ ## library ## _ ## symbol) { \
   printf("Exporting stdcall '%s' from '%s'\n", #symbol, #library); \
 } \
 returnType library ## _ ## symbol()


### PR DESCRIPTION
This changes 2 things to achieve compatibility with MSVC:

* The GNU specific function attribute `constructor` was replaced by a new `INITIALIZER(_name)` macro which creates a function which behaves similar on MSVC and GNU. Please confirm if this still works in clang or other compilers.
Ports to other compilers would be appreciated.

* The heap size was at 2 GiB which already caused overflows. Furthermore my Windows VM only had 1 GiB of free RAM left. Overall if feels like Windows is somewhat worse at overcomitting or giving you the RAM you ask for. 1 GiB is still enough for testing until someone fixes #14 .

I've tested this change with the latest x64 MinGW (MSYS2), x86/x64 MSVC 2017 (Windows 10), and x64 gcc (Arch Linux).
Please test if this change still works on macOS @mborgerson

*(I'll leave this open for 1-2 days probably, unless I can confirm that this works fine on macOS earlier)*