### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+matrix:
+  include:
+    - os: osx
+      env: NAME="macOS build"
+      sudo: false
+      osx_image: xcode7.3
+      install: "./.travis/macos/install.sh"
+      script: "./.travis/macos/script.sh"
+    - os: linux
+      env: NAME="Ubuntu build"
+      sudo: required
+      dist: trusty
+      services: docker
+      install: "./.travis/ubuntu/install.sh"
+      script: "./.travis/ubuntu/script.sh"
+
+notifications:
+  email: false

--- a/.travis/macos/install.sh
+++ b/.travis/macos/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+brew update
+brew install sdl2 unicorn glew openal-soft enet 

--- a/.travis/macos/script.sh
+++ b/.travis/macos/script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+set -o pipefail
+
+export MACOSX_DEPLOYMENT_TARGET=10.9
+
+mkdir build && cd build
+cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;x86_64h" -DCMAKE_BUILD_TYPE=Release
+make -j4

--- a/.travis/ubuntu/docker.sh
+++ b/.travis/ubuntu/docker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+
+cd /openswe1r
+
+apt-get update
+apt-get install -y build-essential libsdl2-dev libopenal-dev libenet-dev libglew-dev wget git
+
+# Get a recent version of CMake
+wget -nv https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh
+echo y | sh cmake-3.9.0-Linux-x86_64.sh --prefix=cmake
+export PATH=/openswe1r/cmake/cmake-3.9.0-Linux-x86_64/bin:$PATH
+
+mkdir build && cd build
+
+# Install unicorn from source
+mkdir unicorn
+cd unicorn
+wget -nv https://github.com/unicorn-engine/unicorn/archive/1.0.1.tar.gz
+tar xf 1.0.1.tar.gz --strip-components=1
+UNICORN_ARCHS="x86" ./make.sh
+export UNICORNDIR="`pwd`"
+cd ..
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4

--- a/.travis/ubuntu/install.sh
+++ b/.travis/ubuntu/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+docker pull ubuntu:16.04

--- a/.travis/ubuntu/script.sh
+++ b/.travis/ubuntu/script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker run -v $(pwd):/openswe1r ubuntu:16.04 /bin/bash -ex /openswe1r/.travis/ubuntu/docker.sh


### PR DESCRIPTION
This adds CI for Ubuntu 16.04 and macOS (both on their native architecture, which is x64).
No deployment is currently made. This is strictly for testing compilation.

I'll probably make a clang-format pass later, but for now it would be pointless with the codebase being such a mess.

We should create an issue after merge, about adding the temporary unicorn compilation result to the travis cache for performance reasons.

While this is in review, I'll probably have to change some travis settings so the CI is ran under the right conditions.

The travis files have been stolen from citra-emu/citra. We should keep an eye on them so we can keep it updated.

Closes #12 

*(Will be merged in a day or so if there is no veto)*