### PR TITLE
Implement Z-buffer

### DIFF
--- a/com/d3d.h
+++ b/com/d3d.h
@@ -320,4 +320,13 @@ typedef enum {
   API(D3DBLEND_INVSRCCOLOR2)     = 17
 } API(D3DBLEND);
 
+enum {
+  API(DDCAPS_3D) =              0x00000001l,
+  API(DDCAPS_BLTDEPTHFILL) =    0x10000000l
+};
+
+enum {
+  API(DDCAPS2_CANRENDERWINDOWED) = 0x00080000l
+};
+
 #endif

--- a/com/ddraw.h
+++ b/com/ddraw.h
@@ -131,6 +131,7 @@ typedef struct {
 
 enum {
   API(DDSCAPS_TEXTURE) = 0x00001000,
+  API(DDSCAPS_ZBUFFER) = 0x00020000,
   API(DDSCAPS_MIPMAP)  = 0x00400000
 };
 
@@ -175,9 +176,58 @@ typedef struct {
   uint32_t      dwTextureStage;
 } API(DDSURFACEDESC2);
 
+typedef struct {
+  uint32_t dwSize;				// size of structure
+  uint32_t dwDDFX;				// FX operations
+  uint32_t dwROP;				// Win32 raster operations
+  uint32_t dwDDROP;			// Raster operations new for DirectDraw
+  uint32_t dwRotationAngle;		// Rotation angle for blt
+  uint32_t dwZBufferOpCode;		// ZBuffer compares
+  uint32_t dwZBufferLow;			// Low limit of Z buffer
+  uint32_t dwZBufferHigh;			// High limit of Z buffer
+  uint32_t dwZBufferBaseDest;		// Destination base value
+  uint32_t dwZDestConstBitDepth;		// Bit depth used to specify Z constant for destination
+  union {
+    uint32_t dwZDestConst;			// Constant to use as Z buffer for dest
+    Address lpDDSZBufferDest;	// Surface to use as Z buffer for dest
+  };
+  uint32_t dwZSrcConstBitDepth;		// Bit depth used to specify Z constant for source
+  union {
+    uint32_t dwZSrcConst;			// Constant to use as Z buffer for src
+    Address lpDDSZBufferSrc;	// Surface to use as Z buffer for src
+  };
+  uint32_t dwAlphaEdgeBlendBitDepth;	// Bit depth used to specify constant for alpha edge blend
+  uint32_t dwAlphaEdgeBlend;		// Alpha for edge blending
+  uint32_t dwReserved;
+  uint32_t dwAlphaDestConstBitDepth;	// Bit depth used to specify alpha constant for destination
+  union {
+    uint32_t dwAlphaDestConst;		// Constant to use as Alpha Channel
+    Address lpDDSAlphaDest;	// Surface to use as Alpha Channel
+  };
+  uint32_t dwAlphaSrcConstBitDepth;	// Bit depth used to specify alpha constant for source
+  union {
+    uint32_t dwAlphaSrcConst;		// Constant to use as Alpha Channel
+    Address lpDDSAlphaSrc;	// Surface to use as Alpha Channel
+  };
+  union {
+    uint32_t dwFillColor;			// color in RGB or Palettized
+    uint32_t   dwFillDepth;                    // depth value for z-buffer
+    uint32_t dwFillPixel;			// pixel value for RGBA or RGBZ
+    Address lpDDSPattern;	// Surface to use as pattern
+  };
+  API(DDCOLORKEY)	ddckDestColorkey;		// DestColorkey override
+  API(DDCOLORKEY)	ddckSrcColorkey;		// SrcColorkey override
+} API(DDBLTFX);
+
 enum {
   API(DDPF_ALPHAPIXELS) = 0x00000001,
   API(DDPF_RGB) =         0x00000040
+};
+
+enum {
+  API(DDBLT_COLORFILL) = 0x00000400l,
+  API(DDBLT_WAIT)      = 0x01000000l,
+  API(DDBLT_DEPTHFILL) = 0x02000000l
 };
 
 typedef struct {

--- a/main.c
+++ b/main.c
@@ -359,6 +359,7 @@ static void LoadVertices(unsigned int vertexFormat, Address address, unsigned in
   glBufferData(GL_ARRAY_BUFFER, count * stride, Memory(address), GL_STREAM_DRAW);
 }
 
+bool depthMask;
 GLenum destBlend;
 GLenum srcBlend;
 uint32_t fogColor; // ARGB
@@ -434,6 +435,8 @@ static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexForma
   // Wireframe mode
   glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 #endif
+
+  glDepthMask(depthMask ? GL_TRUE : GL_FALSE);
 
   GLenum mode;
   switch(primitiveType) {
@@ -2645,8 +2648,6 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
     case API(D3DRENDERSTATE_ZENABLE):
       //FIXME
       glSet(GL_DEPTH_TEST, b);
-      // Hack: While Z is not correct, we can't turn on z-test
-      glDisable(GL_DEPTH_TEST);
       break;
 
     case API(D3DRENDERSTATE_FILLMODE):
@@ -2660,7 +2661,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
       break;
 
     case API(D3DRENDERSTATE_ZWRITEENABLE):
-      glDepthMask(b ? GL_TRUE : GL_FALSE);
+      depthMask = b;
       break;
 
     case API(D3DRENDERSTATE_ALPHATESTENABLE):
@@ -2683,7 +2684,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
 
     case API(D3DRENDERSTATE_ZFUNC):
       assert(b == 4);
-      //FIXME
+      glDepthFunc(GL_LEQUAL);
       break;
 
     case API(D3DRENDERSTATE_ALPHAFUNC):

--- a/main.c
+++ b/main.c
@@ -1913,8 +1913,9 @@ HACKY_COM_BEGIN(IDirectDraw4, 11)
 
   printf("halCaps is %d bytes (known: %d bytes)\n", halCaps->dwSize, sizeof(API(DDCAPS)));
 
-  halCaps->dwCaps = 0x00000001;
-  halCaps->dwCaps2 = 0x00080000;
+  halCaps->dwCaps = API(DDCAPS_3D) | API(DDCAPS_BLTDEPTHFILL);
+  halCaps->dwCaps2 = API(DDCAPS2_CANRENDERWINDOWED);
+
   halCaps->dwVidMemTotal = 16*1024*1024; // 16MiB VRAM free :)
   halCaps->dwVidMemFree = 12*1024*1024; // 12MiB VRAM free :(
   
@@ -2264,7 +2265,7 @@ HACKY_COM_BEGIN(IDirect3D3, 3)
     desc->dwSize = sizeof(API(D3DDEVICEDESC));
     desc->dwFlags = 0xFFFFFFFF;
 
-    desc->dwDeviceZBufferBitDepth = 24;
+    desc->dwDeviceZBufferBitDepth = 16;
 
 enum {
   API(D3DPTEXTURECAPS_PERSPECTIVE) =   0x00000001L,

--- a/main.c
+++ b/main.c
@@ -2039,10 +2039,34 @@ HACKY_COM_BEGIN(IDirectDrawSurface4, 5)
   hacky_printf("a 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
   hacky_printf("c 0x%" PRIX32 "\n", stack[4]);
-  hacky_printf("d 0x%" PRIX32 "\n", stack[5]);
-  hacky_printf("e 0x%" PRIX32 "\n", stack[6]);
+  uint32_t d = stack[5];
+  uint32_t e = stack[6];
+  hacky_printf("d 0x%08" PRIX32 "\n", d);
+  hacky_printf("e 0x%" PRIX32 "\n", e);
 
-  //SDL_GL_SwapWindow(sdlWindow);
+  API(DirectDrawSurface4)* this = (API(DirectDrawSurface4)*)Memory(stack[1]);
+
+  API(DDBLTFX)* bltfx = Memory(e);
+
+  assert((d & ~(API(DDBLT_COLORFILL) | API(DDBLT_WAIT) | API(DDBLT_DEPTHFILL))) == 0);
+
+  if (d & API(DDBLT_WAIT)) {
+    // nop
+  }
+
+  if (d & API(DDBLT_COLORFILL)) {
+    //FIXME: Implement color fill
+  }
+
+  if (d & API(DDBLT_DEPTHFILL)) {
+    assert(this->desc.ddsCaps.dwCaps & API(DDSCAPS_ZBUFFER));
+    assert(this->desc.ddpfPixelFormat.dwZBufferBitDepth == 16);
+
+    glDepthMask(GL_TRUE);
+    assert(bltfx->dwFillDepth = 0xFFFF);
+    glClearDepthf(1.0f); //FIXME!!
+    glClear(GL_DEPTH_BUFFER_BIT);
+  }
 
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 6 * 4;


### PR DESCRIPTION
This implements all functionality to get working depth-testing.

First , the hardware capabilities for filling Z-buffers will be reported with this change. This is the feature the game will test to enable the Z-buffer clearing.
Furthermore, the reported Z-Buffer precision was reduced to 16 bits to make synchronization with OpenGL easier. This will be important in a later change when Z-buffer readback is implemented, but we might as well do it now.
(The internal Z-buffer precision might be higher, but emulated 16 bit is fine for now)

Then actual Z-clearing (or depth filling / clearing) is implemented. This currently assumes that the game always sets the maximum Z value, which is 0xFFFF for our 16 bit Z-buffer. This will be improved in the future if necessary (to support other clear values).

Now that Z-clearing is functional, we can turn on Z-buffering by synchronizing OpenGL and the emulated D3D states.
As a hack, we always assume the `LEQUAL` comparison. More states will be added when they are encountered.
We also have to lazily synchronize the `glDepthMask` because we always have to enable depth writes for the Z-clear from the previous commit.

Note that color clearing and fog are still not implemented, so there'll still be a lot of graphical glitches on some maps (mostly related to distant objects).

**Screenshots:**

* [Menu before](https://i.imgur.com/KFPEmIj.png) / [Menu after](https://i.imgur.com/nQiyPbH.png)
* [Ingame before](https://i.imgur.com/C5buMa4.png) / [Ingame after](https://i.imgur.com/NbOHCQu.png)

*(I'll probably merge this in a day or so but I might not get around to doing it too soon, as I'm busy setting up a CLA)*