### PR TITLE
Introduce a Contributor License Agreement (CLA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OpenSWE1R)       [![Travis build Status](https://travis-ci.org/OpenSWE1R/openswe1r.svg?branch=master)](https://travis-ci.org/OpenSWE1R/openswe1r)       [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/92s5hpto3kvn8sx3/branch/master?svg=true)](https://ci.appveyor.com/project/JayFoxRox82949/openswe1r/branch/master)
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OpenSWE1R)       [![CLA assistant](https://cla-assistant.io/readme/badge/OpenSWE1R/openswe1r)](https://cla-assistant.io/OpenSWE1R/openswe1r)       [![Travis build Status](https://travis-ci.org/OpenSWE1R/openswe1r.svg?branch=master)](https://travis-ci.org/OpenSWE1R/openswe1r)       [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/92s5hpto3kvn8sx3/branch/master?svg=true)](https://ci.appveyor.com/project/JayFoxRox82949/openswe1r/branch/master)
 
 ---
 
@@ -76,6 +76,9 @@ Copy it to your game folder and run it.
 
 Development happens on GitHub at https://github.com/OpenSWE1R/openswe1r
 You can help by reviewing other peoples Pull-Requests or sending your own after forking.
+
+If you want to contribute, you'll have to [sign our Contributor License Agreement (CLA)](https://cla-assistant.io/OpenSWE1R/openswe1r).
+The CLA allows us to easily switch to other [licenses the FSF classifies as Free Software License](https://www.gnu.org/licenses/license-list.html) and which are [approved by the OSI as Open Source licenses](https://opensource.org/licenses), if the need should ever arise ([more information](https://github.com/OpenSWE1R/openswe1r/pull/95)).
 
 ---
 


### PR DESCRIPTION
When this is merged we (the OpenSWE1R maintainers) will add a requirement to sign a [Contributor License Agreement (CLA)](https://en.wikipedia.org/wiki/Contributor_License_Agreement#Rationale) for all future PRs to this repository. We'll be using [CLA assistant](https://github.com/cla-assistant/cla-assistant) to enforce it.

[**The planned CLA can be found here.**](https://gist.github.com/JayFoxRox/806f8a50e599985e52bd73e5a7cb1524)

## Reasoning

Having a CLA is beneficial as it allows us to [relicense contributions at a later time](https://en.wikipedia.org/wiki/Software_relicensing).
While this might sound scary to some, we feel that it is a necessity.

History has shown that [Software re-licensing can be a complicated and lengthy process](http://mamedev.org/?p=422). It is often necessary because the original license is not suitable anymore or found to be invalid.

A good example is the GPL incompatibility of the Apple Appstore and similar platforms. If we want to release OpenSWE1R for iOS devices through the platforms official channels in the future, we'd have to make that particular release under another license (like the BSD or MIT licenses). However, we'd have to get permission from every contributor to do so.
Another issue could be compatibilty with platform specific APIs like the Steam "Steamworks" API.
Once multiplayer is implemented, people might also start making changes which won't have to be open-source (as the GPL intends) - switching to an AGPL license would protect us in such cases.
Use in other game engines such as Unity or Unreal-Engine might require the use of the LGPL.

## What will change

Having a CLA allows us to change the license (and dual-license) in the future. The planned CLA will allow us to license all contributions "under the terms of any licenses the Free Software Foundation classifies as Free Software License and which are approved by the Open Source Initiative as Open Source licenses."

We won't have to contact people many years after they made their contributions. Instead, we ask for permission when the contribution is made.

Other people who would want to license OpenSWE1R differently will simply have to ask the maintainers, even when some of the original contributors would be hard or impossible to reach.

---

As legal stuff is boring (and scary), we've tried to keep the agreement as short as possible (We hope we did not accidentally invalidate the CLA in the process or added any new issues 😟 ).

The CLA does not require any personal information - just clicking a single button is enough for us.

The CLA is currently governed by laws of Germany, simply because that's where I (JayFoxRox), the projects founder, comes from. In the future, that might change to the US as more maintainers join the project.

*We are currently not able to release OpenSWE1R under a non-GPL license anyway. Unicorn, one of our main dependencies, is licensed under the GPL. However, once the need for Unicorn is gone, we might want the option to release OpenSWE1R under a different license for reasons such as those stated above.*

*Also, we do not intend to switch away from the GPL in the foreseeable future. We just want the option of adapting a new license if the circumstances make it necessary.*