### PR TITLE
Implement alpha testing

### DIFF
--- a/main.c
+++ b/main.c
@@ -362,6 +362,7 @@ static void LoadVertices(unsigned int vertexFormat, Address address, unsigned in
 bool depthMask;
 GLenum destBlend;
 GLenum srcBlend;
+bool alphaTest;
 uint32_t fogColor; // ARGB
 bool fogEnable;
 float fogStart;
@@ -404,6 +405,8 @@ static GLenum SetupRenderer(unsigned int primitiveType, unsigned int vertexForma
 
   glUniform1i(glGetUniformLocation(program, "tex0"), 0);
   glUniformMatrix4fv(glGetUniformLocation(program, "projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+
+  glUniform1i(glGetUniformLocation(program, "alphaTest"), alphaTest);
 
   glUniform1i(glGetUniformLocation(program, "fogEnable"), fogEnable);
   glUniform1f(glGetUniformLocation(program, "fogStart"), fogStart);
@@ -2701,8 +2704,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
       break;
 
     case API(D3DRENDERSTATE_ALPHATESTENABLE):
-      //FIXME: Does not exist in GL 3.3 anymore
-      //glSet(GL_ALPHA_TEST, b);
+      alphaTest = b;
       break;
 
     case API(D3DRENDERSTATE_SRCBLEND):
@@ -2724,8 +2726,7 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
       break;
 
     case API(D3DRENDERSTATE_ALPHAFUNC):
-      assert(b == 6);
-      //FIXME
+      assert(b == 6); // D3DCMP_NOTEQUAL
       break;
 
     case API(D3DRENDERSTATE_DITHERENABLE):

--- a/shaders.h
+++ b/shaders.h
@@ -35,6 +35,7 @@ static const char* FragmentShader1Texture =
 "#version 330\n"
 "\n"
 "uniform sampler2D tex0;\n"
+"uniform bool alphaTest;\n"
 "\n"
 "in vec4 diffuse;\n"
 "in vec4 specular;\n"
@@ -49,6 +50,7 @@ static const char* FragmentShader1Texture =
 "void main() {\n"
 "  color = texture(tex0, uv0);\n"
 "  color *= diffuse;\n"
+"  if (alphaTest && !(int(round(color.a * 255.0)) != 0)) { discard; }\n"
 "}\n";
 
 #endif


### PR DESCRIPTION
This implements alpha testing.

As OpenGL 3.3 Core does not have this feature anymore, we have to implement it in GLSL.
I've only seen the game use the `D3DCMP_NOTEQUAL` mode, so it's hardcoded in the shader. 
The alpha-ref is also never set, so it's also the default (0x00) and hardcoded in the shader.
Further modes and the alpha-ref will be implemented as they are encountered.

I assumed an alpha value of 0x00 = 0.0 and 1.0 = 0xFF; with proper rounding (so it's not biased towards 0x00 (`floor`) or 0xFF (`ceil`))
Threfore, the `round()` in the shader is necessary because the GLSL spec says "When constructors are used to convert any floating-point type to an integer type, the fractional part of the floating-point value is dropped." (`floor`).
Actually, doing a `floor()` (or simply removing the `round()`) would make it more likely that pixels get discarded. This would make the following glitch disappear completly:

![Screenshot after merging this PR](https://i.imgur.com/tLDaJcC.png)
([Click here to see how severe the issue is on master, without any alpha-testing](https://i.imgur.com/F2omTP2.png))

For accuracy, I recreated the expected original behaviour (using `round()`). We should test how this behaves on original 90'ies hardware and consider changing it in our D3D implementation. For now, it is assumed that the pictured glitch is just a glitch in the PC version of the original game.

Closes #41 