### PR TITLE
Stub more threading functions

### DIFF
--- a/main.c
+++ b/main.c
@@ -1295,6 +1295,26 @@ HACKY_IMPORT_BEGIN(DeleteCriticalSection)
   esp += 1 * 4;
 HACKY_IMPORT_END()
 
+HACKY_IMPORT_BEGIN(SuspendThread)
+  hacky_printf("hThread 0x%" PRIX32 "\n", stack[1]);
+  eax = 0; // FIXME: Suspend count or -1 in case of error
+  esp += 1 * 4;
+HACKY_IMPORT_END()
+
+HACKY_IMPORT_BEGIN(ResumeThread)
+  hacky_printf("hThread 0x%" PRIX32 "\n", stack[1]);
+  eax = 0; // FIXME: Suspend count or -1 in case of error
+  esp += 1 * 4;
+HACKY_IMPORT_END()
+
+HACKY_IMPORT_BEGIN(TerminateThread)
+  hacky_printf("hThread 0x%" PRIX32 "\n", stack[1]);
+  hacky_printf("dwExitCode 0x%" PRIX32 "\n", stack[2]);
+  //FIXME: This should exit the particular thread
+  eax = 1; // BOOL; non-zero on success
+  esp += 2 * 4;
+HACKY_IMPORT_END()
+
 HACKY_IMPORT_BEGIN(ExitThread)
   hacky_printf("dwExitCode 0x%" PRIX32 "\n", stack[1]);
   printf("\n\n\n\n\nMASSIVE HACK! STARTING NOW!\n\n\n\n\n");


### PR DESCRIPTION
These functions might be called by the audio system to kill or revive the streaming-thread.
In certain scenarios, the audio configuration can cause some of these to be called at startup.
By stubbing these, we therefore avoid crashes at startup or exit.

Note that the audiosystem will still crash at exit in some configurations, as the listener `::Release` function is not implemented.

Closes #48