### PR TITLE
Identify game version using COFF timestamp

### DIFF
--- a/main.c
+++ b/main.c
@@ -3867,6 +3867,22 @@ int main(int argc, char* argv[]) {
   }
   RelocateExe(exe);
 
+  // Attempt to identify the game version using the COFF timestamp
+  if (exe->coffHeader.timeDateStamp == 0x3727ce0e) {
+    printf("Game version: Retail, English\n");
+  } else if (exe->coffHeader.timeDateStamp == 0x3738c552) {
+    printf("Game version: Retail, German\n"); // International?
+  } else if (exe->coffHeader.timeDateStamp == 0x37582659) {
+    printf("Game version: Webdemo, English\n");
+  } else if (exe->coffHeader.timeDateStamp == 0x3c60692c) {
+    printf("Game version: Patched, English\n");
+  } else if (exe->coffHeader.timeDateStamp == 0x3c6321d1) {
+    printf("Game version: Patched, International\n");
+  } else {
+    printf("Game version: Unknown (COFF timestamp: 0x%08X)\n", exe->coffHeader.timeDateStamp);
+    assert(false);
+  }
+
   clearEax = Allocate(3);
   uint8_t* p = Memory(clearEax);
   *p++ = 0x31; *p++ = 0xC0; // xor eax, eax


### PR DESCRIPTION
This uses some of the information gathered in #61 to identify the game version. It will be necessary when implementing #8 .

This should be considere a test for the method of detection and as a publicly available tool to help OpenSW1R users to gather useful information.

As the output might be slightly hidden, you can run `./openswe1r | grep "Game version"`

**If it outputs something like "Game version: Unknown (...)"..**
OR
**..if the output does not match your game version (wrong language / region or something):**

Please respond with the COFF timestamp and more information about your version of the game: CD / DVD version, was it patched from some cover disc or official update (which one?), supported language, md5sum of binary, .. in #61