### PR TITLE
Assert that all used renderstates are known

### DIFF
--- a/com/d3d.h
+++ b/com/d3d.h
@@ -344,4 +344,47 @@ enum {
   API(D3DPTBLENDCAPS_ADD) =              0x00000080L
 };
 
+// Subset of actual type
+typedef enum {
+  API(D3DANTIALIAS_NONE)          = 0
+} API(D3DANTIALIASMODE);
+
+// Subset of actual type
+typedef enum {
+  API(D3DFILL_SOLID)          = 3
+} API(D3DFILLMODE);
+
+// Subset of actual type
+typedef enum {
+  API(D3DSHADE_GOURAUD)           = 2
+} API(D3DSHADEMODE);
+
+// Subset of actual type
+typedef enum {
+  API(D3DTBLEND_MODULATE)         = 2,
+  API(D3DTBLEND_MODULATEALPHA)    = 4
+} API(D3DTEXTUREBLEND);
+
+// Subset of actual type
+typedef enum {
+  API(D3DFILTER_MIPNEAREST)       = 3
+} API(D3DTEXTUREFILTER);
+
+// Subset of actual type
+typedef enum {
+  API(D3DCULL_NONE)               = 1
+} API(D3DCULL);
+
+// Subset of actual type
+typedef enum {
+  API(D3DCMP_LESSEQUAL)           = 4,
+  API(D3DCMP_NOTEQUAL)            = 6
+} API(D3DCMPFUNC);
+
+// Subset of actual type
+typedef enum {
+  API(D3DFOG_NONE)                = 0,
+  API(D3DFOG_LINEAR)              = 3
+} API(D3DFOGMODE);
+
 #endif

--- a/main.c
+++ b/main.c
@@ -2767,79 +2767,144 @@ HACKY_COM_BEGIN(IDirect3DDevice3, 22)
   uint32_t a = stack[2];
   uint32_t b = stack[3];
   switch(a) {
+    case API(D3DRENDERSTATE_TEXTUREHANDLE):
+      assert(b == 0); // Texture handle for legacy interfaces (Texture,Texture2)
+      // FIXME
+      break;
+
+    case API(D3DRENDERSTATE_ANTIALIAS):
+      assert(b == API(D3DANTIALIAS_NONE)); // D3DANTIALIASMODE
+      // FIXME
+      break;
+
+    case API(D3DRENDERSTATE_TEXTUREPERSPECTIVE):
+      assert(b == 1); // TRUE for perspective correction
+      // FIXME
+      break;
+
     case API(D3DRENDERSTATE_ZENABLE):
-      //FIXME
+      assert(b == 1); // D3DZBUFFERTYPE (or TRUE/FALSE for legacy)
       glSet(GL_DEPTH_TEST, b);
       break;
 
     case API(D3DRENDERSTATE_FILLMODE):
-      assert(b == 3);
-      //FIXME
+      assert(b == API(D3DFILL_SOLID)); // D3DFILLMODE
+      // FIXME
       break;
 
     case API(D3DRENDERSTATE_SHADEMODE):
-      assert(b == 2);
-      //FIXME
+      assert(b == API(D3DSHADE_GOURAUD)); // D3DSHADEMODE
+      // FIXME
+      break;
+
+    case API(D3DRENDERSTATE_MONOENABLE):
+      assert(b == 0); // TRUE to enable mono rasterization
+      // FIXME
       break;
 
     case API(D3DRENDERSTATE_ZWRITEENABLE):
+      assert((b == 0) || (b == 1)); // TRUE to enable z writes
       depthMask = b;
       break;
 
     case API(D3DRENDERSTATE_ALPHATESTENABLE):
+      assert(b == 1); // TRUE to enable alpha tests
       alphaTest = b;
       break;
 
+    case API(D3DRENDERSTATE_TEXTUREMIN):
+      assert(b == API(D3DFILTER_MIPNEAREST)); // D3DTEXTUREFILTER
+      // FIXME
+      break;
+
     case API(D3DRENDERSTATE_SRCBLEND):
+      assert(b == API(D3DBLEND_SRCALPHA)); // D3DBLEND
       srcBlend = mapBlend(b);
       break;
 
     case API(D3DRENDERSTATE_DESTBLEND):
+      assert(b == API(D3DBLEND_INVSRCALPHA)); // D3DBLEND
       destBlend = mapBlend(b);
       break;
 
+    case API(D3DRENDERSTATE_TEXTUREMAPBLEND):
+      assert((b == API(D3DTBLEND_MODULATE)) || (b == API(D3DTBLEND_MODULATEALPHA))); // D3DTEXTUREBLEND
+      // FIXME
+      break;
+
     case API(D3DRENDERSTATE_CULLMODE):
-      assert(b == 1);
-      //FIXME
+      assert(b == API(D3DCULL_NONE)); // D3DCULL
+      // FIXME
       break;
 
     case API(D3DRENDERSTATE_ZFUNC):
-      assert(b == 4);
+      assert(b == API(D3DCMP_LESSEQUAL)); // D3DCMPFUNC
       glDepthFunc(GL_LEQUAL);
       break;
 
     case API(D3DRENDERSTATE_ALPHAFUNC):
-      assert(b == 6); // D3DCMP_NOTEQUAL
+      assert(b == API(D3DCMP_NOTEQUAL)); // D3DCMPFUNC
+      // FIXME
       break;
 
     case API(D3DRENDERSTATE_DITHERENABLE):
+      assert(b == 1); // TRUE to enable dithering
       glSet(GL_DITHER, b);
       break;
 
     case API(D3DRENDERSTATE_ALPHABLENDENABLE):
+      assert((b == 0) || (b == 1)); // TRUE to enable alpha blending
       glSet(GL_BLEND, b);
       break;
 
-    //FIXME: Is this a bug? there doesn't seem to be lighting..
-    case API(D3DRENDERSTATE_SPECULARENABLE):
-      //FIXME
-      break;
-
     case API(D3DRENDERSTATE_FOGENABLE):
+      assert((b == 0) || (b == 1)); // TRUE to enable fog blending
       fogEnable = b;
       break;
+
+    case API(D3DRENDERSTATE_SPECULARENABLE):
+      assert(b == 0); // TRUE to enable specular
+      // FIXME
+      break;
+
+    case API(D3DRENDERSTATE_SUBPIXEL):
+      assert(b == 1); // TRUE to enable subpixel correction
+      // FIXME
+      break;
+
+    case API(D3DRENDERSTATE_STIPPLEDALPHA):
+      assert((b == 0) || (b == 1)); // TRUE to enable stippled alpha (RGB device only)
+      // FIXME
+      break;
+
     case API(D3DRENDERSTATE_FOGCOLOR):
+      // D3DCOLOR
       fogColor = b;
       break;
+
+    case API(D3DRENDERSTATE_FOGTABLEMODE):
+      assert((b == API(D3DFOG_NONE)) || (b == API(D3DFOG_LINEAR))); // D3DFOGMODE
+      // FIXME
+      break;
+
     case API(D3DRENDERSTATE_FOGTABLESTART):
+      // Fog start (for both vertex and pixel fog)
       fogStart = *(float*)&b;
       break;
+
     case API(D3DRENDERSTATE_FOGTABLEEND):
+      // Fog end
       fogEnd = *(float*)&b;
       break;
+
+    case API(D3DRENDERSTATE_COLORKEYENABLE):
+      assert(b == 1); // TRUE to enable source colorkeyed textures
+      // FIXME
+      break;
+
     default:
       printf("Unknown render-state %d set to 0x%08" PRIX32 " (%f)\n", a, b, *(float*)&b);
-      //FIXME: assert(false) once this runs faster
+      assert(false);
       break;
   }
   eax = 0; // FIXME: No idea what this expects to return..


### PR DESCRIPTION
This builds on top of the research in #30 
Essentially I've grepped the game for all used SetRenderState calls and then added some that decompilers could not find. I've then tested the games on a handful of courses and ran into no issues (with renderstates).

By breaking into a debugger, this makes it easier to figure out how complete the OpenSWE1R render is, which will be necessary for portability.