### PR TITLE
Add patch for GOG.com CD check

### DIFF
--- a/main.c
+++ b/main.c
@@ -148,11 +148,26 @@ static char* TranslatePath(const char* path) {
     cursor++;
   }
 
-  // The CD install folder will be mapped back to our current directory.
+  // This is a patch for the original CD release.
+  // We simply map the "/gnome/data/" folder from the CD back to our current
+  // folders "/data/" folder.
   // This allows easier installation (by simply copying all files from disc)
-  if ((length >= 9) && !memcmp(newPath, "d:/gnome/", 9)) {
-    memcpy(newPath, "./", 2);
-    memmove(&newPath[2], &newPath[9], length - 9);
+  if ((length >= 14) && !memcmp(newPath, "d:/gnome/data/", 14)) {
+    memcpy(newPath, "./data/", 7);
+    memmove(&newPath[7], &newPath[14], length - 14);
+    return newPath;
+  }
+
+  // This is another CD patch for some patched games.
+  // They search CD contents directly in the CDs "/data/" path (instead of
+  // "/gnome/data/"). This allows them to just set the "CD Path" to the
+  // installation folder of the game.
+  // The most prominent version doing this is probably the GOG.com re-release
+  // from 2018.
+  if ((length >= 8) && !memcmp(newPath, "d:/data/", 8)) {
+    memcpy(newPath, "./data/", 7);
+    memmove(&newPath[7], &newPath[8], length - 8);
+    return newPath;
   }
 
   return newPath;


### PR DESCRIPTION
This adds another cruel patch to the CD check.
Even with this, the GOG.com version felt more "sluggish" and audio made more bad noises than my other installation - I assume the config is just different, as my binary diff has not shown any signs that the binary could be at fault.

With this patch, the original GOG.com version 1.0 (1st of May 2018) / version 1.0 hotfix (4th of May 2018) are "supported". Obviously, all other limitations / issues of OpenSWE1R still apply.
In particular, GOG.com version 1.0 hotfix2 (8th May 2018) is not supported until #153 is also merged.

Strongly affects #142 - the contents of that discussion should be moved to the swe1r-re repository or the wiki.