### PR TITLE
Switch to 16bpp display mode to support GOG.com version 1.0 hotfix2

### DIFF
--- a/main.c
+++ b/main.c
@@ -1982,7 +1982,7 @@ HACKY_COM_BEGIN(IDirectDraw4, 8)
     Address descAddress = Allocate(sizeof(API(DDSURFACEDESC2)));
     API(DDSURFACEDESC2)* desc = Memory(descAddress);
     desc->ddpfPixelFormat.dwFlags = API(DDPF_RGB);
-    desc->ddpfPixelFormat.dwRGBBitCount = 24;
+    desc->ddpfPixelFormat.dwRGBBitCount = 16;
     desc->dwWidth = 640;
     desc->dwHeight = 480;
     desc->lpSurface = 0x01010101;


### PR DESCRIPTION
This changes our display mode to 16bpp.
Although I remember using specifically 24bpp as it's easier to debug issues (as there are only 24bpp framebuffers, but no 24bpp textures).

The reason why this is necessary is explained in https://github.com/OpenSWE1R/openswe1r/issues/142#issuecomment-387745972.
I'm not too happy about this change, as it's already the second patch in OpenSWE1R for the GOG.com version, which shouldn't have to exist in the first place. At this point, the GOG.com version support in OpenSWE1R mostly consists of workarounds for their "dirty" patches.

I've already upstreamed this issue to the GOG.com support, although the damage has already been done.

A proper fix for this in OpenSWE1R would be #152. Until then, this 16bpp mode must be kept.

Closes #151 