### PR TITLE
Add CPack support to provide Win32 binaries and github releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This is the EditorConfig (http://editorconfig.org/) coding style file for
+# openswe1r
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,38 @@ add_executable(openswe1r
   com/dplay.c
 )
 
+# Determine version information
+if(CMAKE_SIZEOF_VOID_P LESS 8)
+  set(APP_BUILD_CONFIG x86)
+else()
+  set(APP_BUILD_CONFIG x64)
+endif()
+if(WIN32)
+  string(APPEND APP_BUILD_CONFIG "-Windows")
+  if(MSVC)
+    string(APPEND APP_BUILD_CONFIG "-MSVC")
+  elseif(MSYS)
+    string(APPEND APP_BUILD_CONFIG "-MSYS")
+  endif()
+elseif(APPLE)
+  string(APPEND APP_BUILD_CONFIG "-macOS")
+else()
+  string(APPEND APP_BUILD_CONFIG "-Linux")
+endif()
+
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/app_version.h
+  PRE_BUILD
+  COMMAND
+    ${CMAKE_COMMAND}
+    -D APP_VERSION_DIR=${CMAKE_BINARY_DIR}
+    -D APP_BUILD_CONFIG=${APP_BUILD_CONFIG}
+    -P cmake/create_app_version.cmake
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+target_sources(openswe1r PUBLIC ${CMAKE_BINARY_DIR}/app_version.h)
+target_include_directories(openswe1r PRIVATE ${CMAKE_BINARY_DIR})
+
 if(USE_VM)
   target_compile_definitions(openswe1r PUBLIC -DUC_KVM)
   target_sources(openswe1r PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,3 +65,8 @@ target_link_libraries(openswe1r
   ${SDL2_LIBRARY}
   ${OPENAL_LIBRARY}
 )
+
+if(MSVC)
+  # Silence MSVC CRT security warnings
+  target_compile_definitions(openswe1r PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ add_custom_command(
 target_sources(openswe1r PUBLIC ${CMAKE_BINARY_DIR}/app_version.h)
 target_include_directories(openswe1r PRIVATE ${CMAKE_BINARY_DIR})
 
+include(package.cmake)
+
 if(USE_VM)
   target_compile_definitions(openswe1r PUBLIC -DUC_KVM)
   target_sources(openswe1r PUBLIC

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OpenSWE1R)       [![CLA assistant](https://cla-assistant.io/readme/badge/OpenSWE1R/openswe1r)](https://cla-assistant.io/OpenSWE1R/openswe1r)       [![Travis build Status](https://travis-ci.org/OpenSWE1R/openswe1r.svg?branch=master)](https://travis-ci.org/OpenSWE1R/openswe1r)       [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/92s5hpto3kvn8sx3/branch/master?svg=true)](https://ci.appveyor.com/project/JayFoxRox82949/openswe1r/branch/master)
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OpenSWE1R)       [![CLA assistant](https://cla-assistant.io/readme/badge/OpenSWE1R/openswe1r)](https://cla-assistant.io/OpenSWE1R/openswe1r)       [![Travis build Status](https://travis-ci.org/OpenSWE1R/openswe1r.svg?branch=master)](https://travis-ci.org/OpenSWE1R/openswe1r)       [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/4fixwemedrccktt3/branch/master?svg=true)](https://ci.appveyor.com/project/OpenSWE1R/openswe1r/branch/master)
 
 ---
 

--- a/app_version.h.in
+++ b/app_version.h.in
@@ -1,0 +1,7 @@
+// Copyright 2017 OpenSWE1R Maintainers
+// Licensed under GPLv2 or any later version
+// Refer to the included LICENSE.txt file.
+
+// THIS FILE IS CREATE AUTOMATICALLY DO NOT EDIT
+
+#define APP_VERSION_STRING "@APP_VERSION@"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,6 +87,7 @@ deploy:
     on:
       appveyor_repo_tag: false
       branch: deployment_test
+      BUILD_TYPE: msvc
 
   - provider: GitHub
     tag: $(appveyor_repo_tag_name)
@@ -98,3 +99,4 @@ deploy:
     on:
       appveyor_repo_tag: true
       branch: deployment_test
+      BUILD_TYPE: msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,3 +62,31 @@ build_script:
 artifacts:
   - path: $(BUILD_TYPE)_build/*.zip
     name: executable
+
+deploy:
+  - provider: GitHub
+    tag: dev-$(appveyor_build_version)
+    release: Development Release $(appveyor_build_version)
+    description: >
+      Automatically created development release $(appveyor_build_version)
+
+      Use this release to test cutting edge features and changes not
+      included in the latest offical release build.
+    prerelease: true
+    repository: TcT2k/openswe1r-unstable
+    auth_token:
+      secure: /WE6q/mVO/ll0+GqpD4PEfC2aTdDqj//FHIRC6TGFMbu5ZP26GUmafH5yD69wkRi
+    on:
+      appveyor_repo_tag: false
+      branch: deployment_test
+
+  - provider: GitHub
+    tag: $(appveyor_repo_tag_name)
+    release: Version $(appveyor_repo_tag_name)
+    description: >
+      Stable release version $(appveyor_build_version)
+    auth_token:
+      secure: /WE6q/mVO/ll0+GqpD4PEfC2aTdDqj//FHIRC6TGFMbu5ZP26GUmafH5yD69wkRi
+    on:
+      appveyor_repo_tag: true
+      branch: deployment_test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # shallow clone
 clone_depth: 10
 
+version: '{build}'
+
 cache:
   - C:\tools\vcpkg\installed\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,8 @@ install:
         }
 
 before_build:
-  - mkdir %BUILD_TYPE%_build
-  - cd %BUILD_TYPE%_build
+  - mkdir build
+  - cd build
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
           C:\msys64\usr\bin\bash.exe -lc "cmake -G 'MSYS Makefiles' -DCMAKE_BUILD_TYPE=Release .. 2>&1"
@@ -53,14 +53,14 @@ before_build:
 build_script:
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
-          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -j4 -C mingw_build/ 2>&1'
+          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -j4 -C build/ 2>&1'
         } else {
-          msbuild msvc_build/openswe1r.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+          msbuild build/openswe1r.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
         }
-  - cmake --build %BUILD_TYPE%_build --config Release --target package
+  - cmake --build build --config Release --target package
 
 artifacts:
-  - path: $(BUILD_TYPE)_build/*.zip
+  - path: build/*.zip
     name: executable
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,3 +57,8 @@ build_script:
         } else {
           msbuild msvc_build/openswe1r.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
         }
+  - cmake --build %BUILD_TYPE%_build --config Release --target package
+
+artifacts:
+  - path: $(BUILD_TYPE)_build/*.zip
+    name: executable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,12 +81,12 @@ deploy:
       Use this release to test cutting edge features and changes not
       included in the latest offical release build.
     prerelease: true
-    repository: TcT2k/openswe1r-unstable
+    repository: OpenSWE1R/openswe1r-unstable
     auth_token:
-      secure: /WE6q/mVO/ll0+GqpD4PEfC2aTdDqj//FHIRC6TGFMbu5ZP26GUmafH5yD69wkRi
+      secure: dt7LXTsIxqTkmXC0FdK7k7K23ifilaIvb0wFXCVDhrNk6u6myk6I0Zgz/FwQ1nFf
     on:
       appveyor_repo_tag: false
-      branch: deployment_test
+      branch: master
       BUILD_TYPE: msvc
 
   - provider: GitHub
@@ -95,8 +95,8 @@ deploy:
     description: >
       Stable release version $(appveyor_build_version)
     auth_token:
-      secure: /WE6q/mVO/ll0+GqpD4PEfC2aTdDqj//FHIRC6TGFMbu5ZP26GUmafH5yD69wkRi
+      secure: dt7LXTsIxqTkmXC0FdK7k7K23ifilaIvb0wFXCVDhrNk6u6myk6I0Zgz/FwQ1nFf
     on:
       appveyor_repo_tag: true
-      branch: deployment_test
+      branch: master
       BUILD_TYPE: msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ version: '{build}'
 
 cache:
   - C:\tools\vcpkg\installed\
+  - C:\projects\unicorn\mingw-w64-x86_64-unicorn-1.0.1-1-any.pkg.tar.xz
 
 os: Visual Studio 2017 Preview
 
@@ -29,11 +30,16 @@ install:
           # redirect err to null to prevent warnings from becoming errors
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-glew mingw-w64-x86_64-openal mingw-w64-x86_64-enet 2>&1"
           # install unicorn from source
-          mkdir unicorn
-          cd unicorn
-          Start-FileDownload 'https://raw.githubusercontent.com/Alexpux/MINGW-packages/master/mingw-w64-unicorn/PKGBUILD'
-          C:\msys64\usr\bin\bash -lc "MINGW_INSTALLS=mingw64 makepkg-mingw -sLf -i --noconfirm  2>&1"
-          cd ..
+          if (Test-Path C:\projects\unicorn\mingw-w64-x86_64-unicorn-1.0.1-1-any.pkg.tar.xz) {
+            C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U C:/projects/unicorn/mingw-w64-x86_64-unicorn-1.0.1-1-any.pkg.tar.xz 2>&1"
+          } else {
+            pushd C:\projects
+            mkdir unicorn
+            cd unicorn
+            Start-FileDownload 'https://raw.githubusercontent.com/Alexpux/MINGW-packages/master/mingw-w64-unicorn/PKGBUILD'
+            C:\msys64\usr\bin\bash -lc "MINGW_INSTALLS=mingw64 makepkg-mingw -sLf -i --noconfirm  2>&1"
+            popd
+          }
           # stick to cmake 3.9.6 since on lower versions it could happen that cmake generates a Makefile that links against gcc_eh
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-cmake-3.9.6-1-any.pkg.tar.xz 2>&1"
         } else {

--- a/cmake/create_app_version.cmake
+++ b/cmake/create_app_version.cmake
@@ -1,0 +1,25 @@
+# This script will determine the current version based on git revision
+# or tag and create information files to be consumed during compile
+# and package time
+
+include(${CMAKE_SOURCE_DIR}/cmake/determine_app_version.cmake)
+
+# Write app version to header if changed
+set(APP_VERSION_FILE_NEEDS_UPDATE TRUE)
+set(APP_VERSION_FILE "${APP_VERSION_DIR}/app_version.h")
+if(EXISTS ${APP_VERSION_FILE})
+  file(READ ${APP_VERSION_FILE} VERSION_H_CONTENTS)
+  string(REGEX MATCH "APP_VERSION_STRING[ \t]+\"(.+)\""
+    FILE_VERSION ${VERSION_H_CONTENTS})
+  string(REGEX MATCH "\"(.+)\""
+    FILE_VERSION ${FILE_VERSION})
+  string(REGEX MATCH "[^\"]+"
+    FILE_VERSION ${FILE_VERSION})
+  if(FILE_VERSION STREQUAL APP_VERSION)
+    set(APP_VERSION_FILE_NEEDS_UPDATE FALSE)
+  endif()
+endif()
+
+if(APP_VERSION_FILE_NEEDS_UPDATE)
+  configure_file("${CMAKE_SOURCE_DIR}/app_version.h.in" ${APP_VERSION_FILE} @ONLY)
+endif()

--- a/cmake/determine_app_version.cmake
+++ b/cmake/determine_app_version.cmake
@@ -1,0 +1,32 @@
+# This script will determine the current version based on git revision or tag
+
+# Determine version number
+
+# When AppVeyor builds a tag use that tags name as version
+if("$ENV{APPVEYOR_REPO_TAG}" STREQUAL "true")
+  set(APP_VERSION $ENV{APPVEYOR_REPO_TAG_NAME})
+else()
+  # Default to git revision
+  execute_process(
+    COMMAND git show -s --format=%h
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_REVISION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  set(APP_VERSION g${GIT_REVISION})
+endif()
+
+# Determine if the current version is "dirty"
+execute_process(
+  COMMAND git status --porcelain
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_STATUS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(GIT_STATUS)
+  string(APPEND APP_VERSION "-dirty")
+endif()
+
+if(APP_BUILD_CONFIG)
+  string(APPEND APP_VERSION "-${APP_BUILD_CONFIG}")
+endif()

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 // Refer to the included LICENSE.txt file.
 
 #include "main.h"
+#include "app_version.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -3943,6 +3944,7 @@ void RunX86(Exe* exe) {
 
 int main(int argc, char* argv[]) {
   printf("-- Initializing\n");
+  printf("Version: %s\n", APP_VERSION_STRING);
   InitializeEmulation();
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_EVENTS) < 0) {
 		  printf("Failed to initialize SDL2!\n");
@@ -3965,7 +3967,9 @@ int main(int argc, char* argv[]) {
 	  SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 	  SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
-    sdlWindow = SDL_CreateWindow("OpenSWE1R", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, style);
+    char windowTitle[200];
+    snprintf(windowTitle, 200, "OpenSWE1R (Version: %s)", APP_VERSION_STRING);
+    sdlWindow = SDL_CreateWindow(windowTitle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, style);
 	  assert(sdlWindow != NULL);
 
 	  SDL_GLContext glcontext = SDL_GL_CreateContext(sdlWindow);

--- a/package.cmake
+++ b/package.cmake
@@ -1,0 +1,46 @@
+# Configure CPack variables before including CPack
+
+set(CPACK_PACKAGE_VENDOR OpenSWE1R)
+set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.txt)
+
+if(NOT CPACK_GENERATOR)
+  # Set default list of supported CPack generators if not specified by the user
+  if(WIN32 OR APPLE)
+    set(CPACK_GENERATOR "ZIP")
+  else()
+    set(CPACK_GENERATOR "TGZ")
+  endif()
+endif()
+
+include(cmake/determine_app_version.cmake)
+set(CPACK_PACKAGE_VERSION ${APP_VERSION})
+set(CPACK_PACKAGE_FILE_NAME OpenSWE1R-${APP_VERSION})
+
+include(CPack)
+
+# Install required files
+set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ".")
+
+# Install main binaries
+install(TARGETS openswe1r
+  RUNTIME DESTINATION ${CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION}
+)
+
+# Install documentation
+install(FILES README.md LICENSE.txt DESTINATION ${CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION})
+
+# Install additional binary modules
+if(MSVC)
+  # Install required runtime libraries
+  include(InstallRequiredSystemLibraries)
+
+  # vcpkg will automatically move the required binaries to the build folder
+  foreach(lib OpenAL32 unicorn SDL2)
+    install(FILES $<TARGET_FILE_DIR:openswe1r>/${lib}.dll
+      DESTINATION ${CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION}
+  )
+  endforeach()
+  install(FILES $<TARGET_FILE_DIR:openswe1r>/glew32$<$<CONFIG:Debug>:d>.dll
+    DESTINATION ${CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION}
+  )
+endif()


### PR DESCRIPTION
Partly as general improvement but also specifically addressing issue #148

* Add CPack support to package binaries (as ZIPs or tar.gz for now)
  * This would also allow other types of packages later on like Windows/mac installers
* Collect package as artifacts in appveyor
* Deploy artifacts as github release like [this](https://github.com/TcT2k/openswe1r/releases)
* Cache unicorn build for MSYS build #92

Open ToDos (some of which I need input on):
- [x] Include version number in executable
  - [x] Print during to log
  - [x] Add to SDL window title
- [x] Decide to always create a release or just for tags
- [x] Releases in same repo or different one
- [x] Release naming (filename currently uses git revision, release name uses appveyor automatic "version number")

I'll create issues for a few open things after this is merged:
* Include MSYS dependencies in package
