### PR TITLE
Allocate memory in MapMemory

### DIFF
--- a/emulation.c
+++ b/emulation.c
@@ -273,15 +273,17 @@ void DumpProfilingHeat(const char* path) {
   }
 }
 
-void MapMemory(void* memory, uint32_t address, uint32_t size, bool read, bool write, bool execute) {
+void* MapMemory(uint32_t address, uint32_t size, bool read, bool write, bool execute) {
   //FIXME: Permissions!
   uc_err err;
   assert(size % ucAlignment == 0);
+  void* memory = aligned_alloc(ucAlignment, size);
   err = uc_mem_map_ptr(uc, address, size, UC_PROT_ALL, memory);
   if (err) {
     printf("Failed on uc_mem_map_ptr() with error returned %u: %s\n", err, uc_strerror(err));
   }
   //FIXME: Add to mapped memory list
+  return memory;
 }
 
 Address Allocate(Size size) {
@@ -428,7 +430,7 @@ void InitializeEmulation() {
 
 #ifndef UC_KVM
   // Setup segments
-  SegmentDescriptor* gdtEntries = (SegmentDescriptor*)aligned_malloc(ucAlignment, AlignUp(gdtSize, ucAlignment));
+  SegmentDescriptor* gdtEntries = (SegmentDescriptor*) = MapMemory(gdtAddress, AlignUp(gdtSize, ucAlignment), true, true, false);
   memset(gdtEntries, 0x00, gdtSize);
 
   gdtEntries[14] = CreateDescriptor(0x00000000, 0xFFFFF000, true);  // CS
@@ -438,8 +440,6 @@ void InitializeEmulation() {
   //FIXME: Remove? We never switch to ring 0 anyway (Came from UC sample code)
   gdtEntries[17] = CreateDescriptor(0x00000000, 0xFFFFF000, false);  // Ring 0
   gdtEntries[17].dpl = 0;  //set descriptor privilege level
-
-  err = uc_mem_map_ptr(uc, gdtAddress, AlignUp(gdtSize, ucAlignment), UC_PROT_WRITE | UC_PROT_READ, gdtEntries);
 
   uc_x86_mmr gdtr;
   gdtr.base = gdtAddress;  
@@ -478,14 +478,12 @@ void InitializeEmulation() {
 #endif
 
   // Map and set TLS (not exposed via flat memory)
-  uint8_t* tls = aligned_malloc(ucAlignment, tlsSize);
+  uint8_t* tls = MapMemory(tlsAddress, tlsSize, true, true, false);
   memset(tls, 0xBB, tlsSize);
-  err = uc_mem_map_ptr(uc, tlsAddress, tlsSize, UC_PROT_WRITE | UC_PROT_READ, tls);
 
   // Allocate a heap
-  heap = aligned_malloc(ucAlignment, heapSize);
+  heap = MapMemory(heapAddress, heapSize, true, true, true);
   memset(heap, 0xAA, heapSize);
-  MapMemory(heap, heapAddress, heapSize, true, true, true);
 }
 
 void SetTracing(bool enabled) {
@@ -548,8 +546,7 @@ unsigned int CreateEmulatedThread(uint32_t eip) {
   // Map and set stack
   //FIXME: Use requested size
   if (stack == NULL) {
-    stack = aligned_malloc(ucAlignment, stackSize);
-    MapMemory(stack, stackAddress, stackSize, true, true, false);
+    stack = MapMemory(stackAddress, stackSize, true, true, false);
   }
   static int threadId = 0;
   uint32_t esp = stackAddress + stackSize / 2 + 256 * 1024 * threadId++; // 256 kiB per late thread

--- a/emulation.h
+++ b/emulation.h
@@ -25,7 +25,7 @@ void RunEmulation();
 
 // Memory API
 
-void MapMemory(void* data, uint32_t address, uint32_t size, bool read, bool write, bool execute);
+void* MapMemory(uint32_t address, uint32_t size, bool read, bool write, bool execute);
 Address Allocate(Size size);
 void Free(Address address);
 void* Memory(uint32_t address);

--- a/main.c
+++ b/main.c
@@ -3959,11 +3959,14 @@ void RunX86(Exe* exe) {
   // Map the important exe parts into emu memory
   for(unsigned int sectionIndex = 0; sectionIndex < exe->coffHeader.numberOfSections; sectionIndex++) {
     PeSection* section = &exe->sections[sectionIndex];
-    void* mappedSection = (void*)exe->mappedSections[sectionIndex];
-    if (mappedSection != NULL) {
+    void** mappedSection = (void**)&exe->mappedSections[sectionIndex];
+    if (*mappedSection != NULL) {
       uint32_t base = exe->peHeader.imageBase + section->virtualAddress;
       printf("Mapping 0x%" PRIX32 " - 0x%" PRIX32 "\n", base, base + section->virtualSize - 1);
-      MapMemory(mappedSection, base, AlignUp(section->virtualSize, exe->peHeader.sectionAlignment), true, true, true);
+      void* relocatedMappedSection = MapMemory(base, AlignUp(section->virtualSize, exe->peHeader.sectionAlignment), true, true, true);
+      memcpy(relocatedMappedSection, *mappedSection, section->virtualSize);
+      aligned_free(*mappedSection);
+      *mappedSection = relocatedMappedSection;
     }
   }
 


### PR DESCRIPTION
This should make it easier to run VM-less in the future, because it should allow to maintain 1:1 host/guest mapping on some platforms (by doing the allocation in `MapMemory`).

I'm still not happy with the design, and it might change again before or after merge.