### PR TITLE
Always check if app_version.h needs to be generated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,8 @@ else()
 endif()
 
 add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/app_version.h
+  OUTPUT ${CMAKE_BINARY_DIR}/.generated
+         ${CMAKE_BINARY_DIR}/app_version.h
   PRE_BUILD
   COMMAND
     ${CMAKE_COMMAND}


### PR DESCRIPTION
I have issues locally, where an outdated git revision is shown in the window title.
The app_version.h generator isn't ran because that file exists already.

This adds a fake target `OUTPUT` file (.generated) to the app_version.h generator.
As that file is never created, it will force recreation of app_version.h.
create_app_version.cmake will still parse the existing file to check if it has to be updated.

The .generated can be created manually to stop the generator from being ran.