### PR TITLE
Lower memory consumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(openswe1r
   emulation.c
   export.c
   shader.c
+  alloc.c
 
   dll/kernel32.c
 

--- a/alloc.c
+++ b/alloc.c
@@ -1,0 +1,139 @@
+// Copyright 2019 OpenSWE1R Maintainers
+// Licensed under GPLv2 or any later version
+// Refer to the included LICENSE.txt file.
+
+// This is a temporary placeholder for a memory allocator.
+
+#include "alloc.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "common.h"
+
+
+typedef struct _Allocator {
+  unsigned int block_count;
+  unsigned int block_size;
+  uint8_t block_usage[1];
+} Allocator;
+
+
+static void block_mark_used(Allocator* allocator, unsigned int block, bool used) {
+  uint8_t mask = 1 << (block % 8);
+  if (used) {
+    allocator->block_usage[block / 8] |= mask;
+  } else {
+    allocator->block_usage[block / 8] &= ~mask;
+  }
+}
+
+static bool block_is_used(Allocator* allocator, unsigned int block) {
+  uint8_t mask = 1 << (block % 8);
+  return allocator->block_usage[block / 8] & mask;
+}
+
+static unsigned int count_blocks(Allocator* allocator, unsigned int block, bool used) {
+  unsigned int count = 0;
+  while(block < allocator->block_count) {
+    if (block_is_used(allocator, block) != used) {
+      break;
+    }
+    block++;
+    count++;
+  }
+  return count;
+}
+
+static unsigned int find_free_blocks(Allocator* allocator, unsigned int needed_blocks) {
+
+  unsigned int best_count = 0;
+  unsigned int best_block = 0;
+
+  unsigned int block = 0;
+  while(block < allocator->block_count) {
+
+    bool block_used = block_is_used(allocator, block);
+    unsigned int available_blocks = count_blocks(allocator, block, block_used);
+
+    // Only look at unused blocks that are large enough
+    if (!block_used && (available_blocks >= needed_blocks)) {
+
+      // Check if we don't have a result yet, or if this is a better fit
+      if ((best_count == 0) || (available_blocks < best_count)) {
+
+        // Update result
+        best_block = block;
+        best_count = available_blocks;
+
+        // If we have an exact fit, use that
+        if (best_count == needed_blocks) {
+          break;
+        }
+
+      }
+    }
+
+    block += available_blocks;
+  }
+
+  // Assert that we have a result
+  assert(best_count != 0);
+
+  // Returns best block address
+  return best_block;
+}
+
+Allocator* alloc_create(unsigned int size, unsigned int block_size) {
+  assert(size % block_size == 0);
+  unsigned int block_count = size / block_size;
+
+  size_t usage_byte_count = (block_count + 7) / 8;
+  Allocator* allocator = malloc(sizeof(Allocator) + usage_byte_count - 1);
+  allocator->block_count = block_count;
+  allocator->block_size = block_size;
+  memset(allocator->block_usage, 0x00, usage_byte_count);
+  return allocator;
+}
+
+void alloc_destroy(Allocator* allocator) {
+  free(allocator);
+}
+
+unsigned int alloc_allocate(Allocator* allocator, unsigned int size) {
+
+  unsigned int aligned_size = AlignUp(size, allocator->block_size);
+  unsigned int count = aligned_size / allocator->block_size;
+
+  // Don't allow zero-size allocations (breaks algorithm)
+  assert(count > 0);
+
+  //FIXME: `+ 2` is a hack, so we can recognize block splits
+  unsigned int block = find_free_blocks(allocator, count + 2) + 1;
+
+  for(unsigned int i = 0; i < count; i++) {
+    block_mark_used(allocator, block + i, true);
+  }
+
+  return block * allocator->block_size;
+}
+
+void alloc_free(Allocator* allocator, unsigned int offset) {
+
+  assert(offset % allocator->block_size == 0);
+  unsigned int block = offset / allocator->block_size;
+
+  unsigned int used_blocks = count_blocks(allocator, block, true);
+
+  // Avoid double-free
+  assert(used_blocks > 0);
+
+  for(unsigned int i = 0; i < used_blocks; i++) {
+    block_mark_used(allocator, block + i, false);
+  }
+
+}

--- a/alloc.h
+++ b/alloc.h
@@ -1,0 +1,18 @@
+// Copyright 2019 OpenSWE1R Maintainers
+// Licensed under GPLv2 or any later version
+// Refer to the included LICENSE.txt file.
+
+#ifndef __OPENSWE1R_ALLOC_H__
+#define __OPENSWE1R_ALLOC_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct _Allocator Allocator;
+
+Allocator* alloc_create(unsigned int size, unsigned int block_size);
+void alloc_destroy(Allocator* allocator);
+unsigned int alloc_allocate(Allocator* allocator, unsigned int size);
+void alloc_free(Allocator* allocator, unsigned int offset);
+
+#endif

--- a/common.h
+++ b/common.h
@@ -14,6 +14,8 @@
 #  include <stdlib.h>
 #endif
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
 static bool IsZero(const void* data, size_t size) {
   uint8_t* bytes = (uint8_t*)data;
   for(size_t i = 0; i < size; i++) {

--- a/main.c
+++ b/main.c
@@ -972,6 +972,11 @@ HACKY_IMPORT_BEGIN(HeapFree)
   hacky_printf("hHeap 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("dwFlags 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("lpMem 0x%" PRIX32 "\n", stack[3]);
+
+  assert(stack[2] == 0x0);
+
+  Free(stack[3]);
+
   eax = 1; // nonzero if succeeds
   esp += 3 * 4;
 HACKY_IMPORT_END()

--- a/main.c
+++ b/main.c
@@ -1066,7 +1066,7 @@ HACKY_IMPORT_BEGIN(DirectDrawCreate)
   hacky_printf("lpGUID 0x%" PRIX32 "\n", stack[1]);
   hacky_printf("lplpDD 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("pUnkOuter 0x%" PRIX32 "\n", stack[3]);
-  *(Address*)Memory(stack[2]) = CreateInterface("IDirectDraw4", 200);
+  *(Address*)Memory(stack[2]) = CreateInterface("IDirectDraw4", 30);
   eax = 0; // DD_OK
   esp += 3 * 4;
 HACKY_IMPORT_END()
@@ -1917,7 +1917,7 @@ HACKY_COM_BEGIN(IDirectDraw4, 0)
     assert(false);
   }
 
-  *(Address*)Memory(stack[3]) = CreateInterface(name, 200);
+  *(Address*)Memory(stack[3]) = CreateInterface(name, 30);
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 3 * 4;
 HACKY_COM_END()
@@ -1936,7 +1936,7 @@ HACKY_COM_BEGIN(IDirectDraw4, 5)
   hacky_printf("b 0x%" PRIX32 "\n", stack[3]);
   hacky_printf("c 0x%" PRIX32 "\n", stack[4]);
   hacky_printf("d 0x%" PRIX32 "\n", stack[5]);
-  *(Address*)Memory(stack[4]) = CreateInterface("IDirectDrawPalette", 200);
+  *(Address*)Memory(stack[4]) = CreateInterface("IDirectDrawPalette", 10);
   eax = 0; // FIXME: No idea what this expects to return..
   esp += 5 * 4;
 HACKY_COM_END()
@@ -1989,7 +1989,7 @@ enum {
     printf("GL handle is %d\n", texture->handle);
   } else {
     //FIXME: only added to catch bugs, null pointer should work
-    surface->texture = CreateInterface("invalid", 200);
+    surface->texture = CreateInterface("invalid", 50);
 
     //FIXME: WTF is this shit?!
     API(Direct3DTexture2)* texture = (API(Direct3DTexture2)*)Memory(surface->texture);
@@ -3546,7 +3546,7 @@ HACKY_COM_BEGIN(IDirectInputA, 3)
   hacky_printf("rguid 0x%" PRIX32 "\n", stack[2]);
   hacky_printf("lpIDD 0x%" PRIX32 "\n", stack[3]);
   hacky_printf("pUnkOuter 0x%" PRIX32 "\n", stack[4]);
-  *(Address*)Memory(stack[3]) = CreateInterface("IDirectInputDeviceA", 200);
+  *(Address*)Memory(stack[3]) = CreateInterface("IDirectInputDeviceA", 20);
   eax = 0; // HRESULT -> non-negative means success
   esp += 4 * 4;
 HACKY_COM_END()


### PR DESCRIPTION
A couple of changes intended to avoid high memory consumption.

An important change is the reuse of file handles, by scanning over all handle slots to find a free one. The assumption is that there'll be very few handles at all time (I've seen 4 at most), so the allocation should be fast.

Another critical change is the use of a fixed-size block allocator for the heap.
It's working similar to the file allocator, but using a bitmap for tracking wether blocks are used or not; however, this will be *slow* and wasteful.
As-is, it will consume about the same memory as before (possibly more), and it will be slower.
This can be tolerated, as future changes (another allocator + free'ing memory) will bring back performance and reduce memory usage significantly.