### PR TITLE
Use GLEW::GLEW to work around CMake 3.15 issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ endif()
 include_directories(SYSTEM
   ${LIBUNICORN_INCLUDE_DIR}
   ${OPENGL_INCLUDE_DIR}
-  ${GLEW_INCLUDE_DIRS}
   ${SDL2_INCLUDE_DIR}
   ${OPENAL_INCLUDE_DIR}
 )
@@ -96,7 +95,7 @@ endif()
 
 target_link_libraries(openswe1r
   ${OPENGL_LIBRARIES}
-  ${GLEW_LIBRARIES}
+  GLEW::GLEW
   ${SDL2_LIBRARY}
   ${OPENAL_LIBRARY}
 )


### PR DESCRIPTION
See https://github.com/OpenSWE1R/openswe1r/issues/180#issuecomment-518016889 for details. 

I was unable to reproduce the issue on Arch Linux (doesn't ship a cmake config as part of glew).
Please report if this fixes it @Thom1729.

I also considered using import targets for the other dependencies. However, the selfmade CMake scripts in cmake/ did not have import targets, and upstream didn't add import targets for OpenGL in CMake 3.1 (which is the current target). OpenAL also still has no import target in CMake 3.15.
Hence, only GLEW was updated to use import targets.

Closes #180 

*This might also warrant a fix in GLEW, because their CMake config shouldn't remove the result variables - it breaks compatibility. At the same time, this should have prevented CMake 3.15 to use glews config.*