### PR TITLE
Refactor KVM includes

### DIFF
--- a/uc_kvm.c
+++ b/uc_kvm.c
@@ -4,28 +4,23 @@
 
 #include <unicorn/unicorn.h>
 
-#include <stdlib.h>
 #include <assert.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <sys/mman.h>
+#include <inttypes.h>
 #include <linux/kvm.h>
 #include <malloc.h>
-#include <assert.h>
-#include <stdint.h>
-#include <stropts.h>
-#include <unistd.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <assert.h>
 #include <pthread.h>
-#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 typedef struct _cbe {
   struct _cbe* next;


### PR DESCRIPTION
Replaces `<stropts.h>` (POSIX) with `<sys/ioctl.h>` (Linux) include to declare `ioctl`.
This works as KVM is only used on Linux currently (so POSIX compatibility is not required); I think some flavors of BSD also adopted KVM, but they are not supported by OpenSWE1R (yet).

I took this opportunity to remove duplicated includes.

Closes #182 
Please confirm that this works for you @Calinou